### PR TITLE
国际配置文件中缺少 commonWatchArticlePermissionLabel 页面报 500错误

### DIFF
--- a/src/main/resources/lang_en_US.properties
+++ b/src/main/resources/lang_en_US.properties
@@ -841,6 +841,7 @@ commonThankArticlePermissionLabel=Thank article
 commonThankCommentPermissionLabel=Thank comment
 commonUseILPermissionLabel=Use invite link
 commonViewArticleHistoryPermissionLabel=View article history
+commonWatchArticlePermissionLabel=View article
 domainAddDomainPermissionLabel=Add domain
 domainAddDomainTagPermissionLabel=Add domain tag
 domainRemoveDomainPermissionLabel=Remove domain

--- a/src/main/resources/lang_zh_CN.properties
+++ b/src/main/resources/lang_zh_CN.properties
@@ -841,6 +841,7 @@ commonThankArticlePermissionLabel=\u611F\u8C22\u5E16\u5B50
 commonThankCommentPermissionLabel=\u611F\u8C22\u56DE\u5E16
 commonUseILPermissionLabel=\u4F7F\u7528\u9080\u8BF7\u94FE\u63A5
 commonViewArticleHistoryPermissionLabel=\u67E5\u770B\u5E16\u5B50\u7F16\u8F91\u5386\u53F2
+commonWatchArticlePermissionLabel=\u67e5\u770b\u5e16\u5b50
 domainAddDomainPermissionLabel=\u6DFB\u52A0\u9886\u57DF
 domainAddDomainTagPermissionLabel=\u6DFB\u52A0\u9886\u57DF\u6807\u7B7E
 domainRemoveDomainPermissionLabel=\u5220\u9664\u9886\u57DF


### PR DESCRIPTION
修改了 管理->角色管理->权限 页面报500错误的问题，由于国际配置文件中缺少 commonWatchArticlePermissionLabel（查看帖子）