### PR TITLE
antiJARLocking is an attribute in Tomcat 7, which has been removed in…

### DIFF
--- a/src/main/webapp/META-INF/context.xml
+++ b/src/main/webapp/META-INF/context.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Context antiJARLocking="true" path="/"/>
+<Context antiResourceLocking="true" path="/"/>


### PR DESCRIPTION
… Tomcat 8.  So, for Tomcat 8, just use antiResourceLocking.

antiJARLocking是Tomcat 7中的一个属性，它已在Tomcat 8中删除。

所以，对于Tomcat 8，只需使用antiResourceLocking。

https://tomcat.apache.org/tomcat-7.0-doc/config/context.html

https://tomcat.apache.org/tomcat-8.0-doc/config/context.html