### PR TITLE
修复发送邮件时日志记录接收人使用数组toString的问题

### DIFF
--- a/src/main/java/org/b3log/symphony/util/Mails.java
+++ b/src/main/java/org/b3log/symphony/util/Mails.java
@@ -564,7 +564,7 @@ final class MailSender implements java.io.Serializable {
 
         // 5、发送邮件
         ts.sendMessage(message, message.getAllRecipients());
-        LOGGER.debug(tos.toString());
+        LOGGER.debug(Arrays.toString(tos));
         LOGGER.debug(subject);
         LOGGER.debug(content);
         ts.close();


### PR DESCRIPTION
你好,我在使用symphony查看代码时看到org.b3log.symphony.util.Mails工具类记录邮件接收人日志时的一个小问题

`    
String[] tos = new String[] {"to1","to2"};           
System.out.println("tos.toString():"+tos.toString());
System.out.println("Arrays.toString(tos):"+Arrays.toString(tos));`

对应的输出
tos.toString():[Ljava.lang.String;@123a439b
Arrays.toString(tos):[to1, to2]

可以看到使用tos.toString()没有打印出数组中的内容

org.b3log.symphony.util.Mails工具类 567行附近的代码

` LOGGER.debug(tos.toString());
 LOGGER.debug(subject);
 LOGGER.debug(content);`



所有我把tos.toString()改为了Arrays.toString(tos)