### PR TITLE
在md5加密时使用""替换new String()来减少不必要的对象创建

### DIFF
--- a/src/main/java/org/b3log/symphony/util/GeetestLib.java
+++ b/src/main/java/org/b3log/symphony/util/GeetestLib.java
@@ -552,7 +552,7 @@ public class GeetestLib {
      * @return
      */
     private String md5Encode(String plainText) {
-        String re_md5 = new String();
+        String re_md5 = "";
         try {
             MessageDigest md = MessageDigest.getInstance("MD5");
             md.update(plainText.getBytes());


### PR DESCRIPTION
你好,我在使用symphony查看代码时看到org.b3log.symphony.util.GeetestLib工具类md5Encode  md5加密方法的一个代码质量问题
`String re_md5 = new String();`
正如String构造方法API文档
`    /**
     * Initializes a newly created {@code String} object so that it represents
     * an empty character sequence.  Note that use of this constructor is
     * unnecessary since Strings are immutable.
     */`
String是不可变的,每次创建String对象是不必要的(除了一些特殊场景,比如把字符串做为锁的对象,利用唯一性)
所以把代码改完了能利用字符串常量池中的空字符串"";减少对象创建
`String re_md5 = "";`
