### PR TITLE
docker运行项目脚本

### DIFF
--- a/scripts/build_docker_container.sh
+++ b/scripts/build_docker_container.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+echo package...
+docker run --rm -it -v $(pwd)/..:/project -w /project maven mvn package
+echo starting mysql...
+docker stop sym-mysql && docker rm sym-mysql
+docker run -d --name sym-mysql -v $(pwd)/data:/var/lib/mysql -e MYSQL_ROOT_PASSWORD=123456 -e MYSQL_DATABASE=b3log_symphony mysql:5.7 --lower_case_table_names=1 --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+echo starting jetty...
+docker stop jetty-sym && docker rm jetty-sym
+docker run -d --name jetty-sym  -v $(pwd)/../target/symphony.war:/var/lib/jetty/webapps/ROOT.war -p 8080:8080 --link sym-mysql:sym-mysql jetty:9.3.24-jre8-alpine


### PR DESCRIPTION
看到原有的dockerfile有点问题，
这个脚本直接创建container运行项目，就不用build啦。
直接运行脚本 然后打开 http://localhost:8080 就可看到项目了。

1. 脚本首先使用docker maven 打包war
2. 再创建了一个名为sym-mysql 的mysql的容器
3. 最后创建了一个名为jetty-sym的jetty容器在8080端口并link到sym-mysql

所以默认需要修改local.properties文件里的jdbc链接为jdbc:mysql://sym-mysql/b3log_symphony?......

需要修改其他端口或者数据库密码请自行修改脚本
